### PR TITLE
statically linked coredns

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,25 +7,22 @@ platform:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.15.2b5
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - sleep 20
-  - TAG=${DRONE_TAG} make
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG}
 
-- name: push
-  image: rancher/hardened-build-base:v1.14.2-amd64
+- name: publish
+  image: rancher/hardened-build-base:v1.15.2b5
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - TAG=${DRONE_TAG} make image-push
+  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
   environment:
     DOCKER_USERNAME:
       from_secret: docker_username
@@ -36,26 +33,12 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.15.2b5
   volumes:
   - name: dockersock
     path: /var/run
   commands:
-  - TAG=${DRONE_TAG} make image-scan
-  when:
-    event:
-    - tag
-
-- name: manifest
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-  - name: dockersock
-    path: /var/run
-  commands:
-  - TAG=${DRONE_TAG} make image-manifest
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG} image-scan
 
 services:
 - name: docker
@@ -66,5 +49,5 @@ services:
     path: /var/run
 
 volumes:
-  - name: dockersock
-    temp: {}
+- name: dockersock
+  temp: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,44 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.14.2-amd64
-
+ARG GO_IMAGE=rancher/hardened-build-base:v1.15.2b5
 FROM ${UBI_IMAGE} as ubi
-
 FROM ${GO_IMAGE} as builder
-ARG TAG="" 
-RUN apt update     && \ 
-    apt upgrade -y && \ 
-    apt install -y ca-certificates git
-
-RUN git clone --depth=1 https://github.com/coredns/coredns.git
-RUN cd /go/coredns                     && \
-    git fetch --all --tags --prune     && \
-    git checkout tags/${TAG} -b ${TAG} && \
-    make all
+# setup required packages
+RUN set -x \
+ && apk --no-cache add \
+    file \
+    gcc \
+    git \
+    make
+# setup containerd build
+ARG TAG="v1.6.9"
+RUN git clone --depth=1 https://github.com/coredns/coredns.git $GOPATH/src/github.com/coredns/coredns
+WORKDIR $GOPATH/src/github.com/coredns/coredns
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+# build statically linked executables
+RUN echo 'GO_BUILD_FLAGS=" \
+        -gcflags=-trimpath=/go/src \
+        -v"' \
+    >> ./go-build-static
+RUN echo 'GO_LDFLAGS=" \
+         -X github.com/coredns/coredns/coremain.GitCommit=$(git rev-parse --short HEAD) \
+         -linkmode=external -extldflags \"-static -Wl,--fatal-warnings\""' \
+    >> ./go-build-static
+RUN echo 'go build ${GO_BUILD_FLAGS} -ldflags "${GO_LDFLAGS}" "${@}"' \
+    >> ./go-build-static
+RUN sh -ex ./go-build-static -o bin/coredns .
+# assert statically linked executables
+RUN echo '[ -e $1 ] && (file $1 | grep -E "executable, x86-64, .*, statically linked")' >> ./assert-static
+RUN sh -ex ./assert-static bin/coredns
+# assert goboring symbols
+RUN echo '[ -e $1 ] && (go tool nm $1 | grep Cfunc__goboring > .boring; if [ $(wc -l <.boring) -eq 0 ]; then exit 1; fi)' \
+    >> ./assert-boring
+RUN sh -ex ./assert-boring bin/coredns
+# install (with strip) to /usr/local/bin
+RUN install -s bin/coredns /usr/local/bin
 
 FROM ubi
-RUN microdnf update -y && \ 
+RUN microdnf update -y && \
     rm -rf /var/cache/yum
-
-COPY --from=builder /go/coredns/coredns /coredns
-
-ENTRYPOINT ["/coredns"]
+COPY --from=builder /usr/local/bin/coredns /usr/local/bin/
+ENTRYPOINT ["coredns"]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,24 @@
 SEVERITIES = HIGH,CRITICAL
 
-.PHONY: all
-all:
+ifneq ($(DRONE_TAG),)
+TAG := $(DRONE_TAG)
+else
+TAG ?= v1.6.9
+endif
+
+.PHONY: image-build
+image-build:
 	docker build --build-arg TAG=$(TAG) -t rancher/hardened-coredns:$(TAG) .
 
 .PHONY: image-push
 image-push:
-	docker push rancher/hardened-coredns:$(TAG) >> /dev/null
-
-.PHONY: scan
-image-scan:
-	trivy --severity $(SEVERITIES) --no-progress --skip-update --ignore-unfixed rancher/hardened-coredns:$(TAG)
+	docker push rancher/hardened-coredns:$(TAG)-$(ARCH)
 
 .PHONY: image-manifest
 image-manifest:
-	docker image inspect rancher/hardened-coredns:$(TAG)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create rancher/hardened-coredns:$(TAG) \
-		$(shell docker image inspect rancher/hardened-coredns:$(TAG) | jq -r '.[] | .RepoDigests[0]')
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create rancher/hardened-coredns:$(TAG) rancher/hardened-coredns:$(TAG)-$(ARCH)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push rancher/hardened-coredns:$(TAG)
+
+.PHONY: image-scan
+image-scan:
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed rancher/hardened-coredns:$(TAG)


### PR DESCRIPTION
Leverage new alpine-based rancher/hardened-build-base (goboring built on
alpine) while matching the upstream version of go to compile with. Also
assert everything is statically linked and assert presence of goboring
symbols prior to install-with-strip.

Addresses rancher/rke2#335
