### PR TITLE
Harden autoscaler

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,8 @@ steps:
   pull: always
   image: rancher/hardened-build-base:v1.15.8b5
   commands:
-  - make DRONE_TAG=${DRONE_TAG}
+  - make DRONE_TAG=${DRONE_TAG} image-build-coredns
+  - make DRONE_TAG=${DRONE_TAG} image-build-autoscaler
   volumes:
   - name: docker
     path: /var/run/docker.sock
@@ -21,7 +22,8 @@ steps:
   image: rancher/hardened-build-base:v1.15.8b5
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
+  - make DRONE_TAG=${DRONE_TAG} image-push-coredns image-manifest-coredns
+  - make DRONE_TAG=${DRONE_TAG} image-push-autoscaler image-manifest-autoscaler
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -37,7 +39,8 @@ steps:
 - name: scan
   image: rancher/hardened-build-base:v1.15.8b5
   commands:
-  - make DRONE_TAG=${DRONE_TAG} image-scan
+  - make DRONE_TAG=${DRONE_TAG} image-scan-coredns
+  - make DRONE_TAG=${DRONE_TAG} image-scan-autoscaler
   volumes:
   - name: docker
     path: /var/run/docker.sock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.15.8b5
+ARG TAG="v1.8.3"
+ARG ARCH="amd64"
 FROM ${UBI_IMAGE} as ubi
-FROM ${GO_IMAGE} as builder
+FROM ${GO_IMAGE} as base-builder
 # setup required packages
 RUN set -x \
  && apk --no-cache add \
@@ -9,10 +11,12 @@ RUN set -x \
     gcc \
     git \
     make
-# setup the build
+
+# setup the coredns build
+FROM base-builder as coredns-builder
 ARG SRC=github.com/coredns/coredns
 ARG PKG=github.com/coredns/coredns
-ARG TAG="v1.8.3"
+ARG TAG
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
@@ -24,8 +28,30 @@ RUN go-assert-boring.sh bin/*
 RUN install -s bin/* /usr/local/bin
 RUN coredns --version
 
-FROM ubi
+# setup the autoscaler build
+FROM base-builder as autoscaler-builder
+ARG SRC=github.com/kubernetes-sigs/cluster-proportional-autoscaler
+ARG PKG=github.com/kubernetes-sigs/cluster-proportional-autoscaler
+RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
+ARG TAG
+ARG ARCH
+WORKDIR $GOPATH/src/${PKG}
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+RUN GOARCH=${ARCH} GO_LDFLAGS="-linkmode=external -X ${PKG}/pkg/version.VERSION=${TAG}" \
+    go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o . ./...
+RUN go-assert-static.sh cluster-proportional-autoscaler
+RUN go-assert-boring.sh cluster-proportional-autoscaler
+RUN install -s cluster-proportional-autoscaler /usr/local/bin
+
+FROM ubi as coredns
 RUN microdnf update -y && \
     rm -rf /var/cache/yum
-COPY --from=builder /usr/local/bin/coredns /coredns
+COPY --from=coredns-builder /usr/local/bin/coredns /coredns
 ENTRYPOINT ["/coredns"]
+
+FROM ubi as autoscaler
+RUN microdnf update -y && \
+    rm -rf /var/cache/yum
+COPY --from=autoscaler-builder /usr/local/bin/cluster-proportional-autoscaler /cluster-proportional-autoscaler
+ENTRYPOINT ["/cluster-proportional-autoscaler"]

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-PKG ?= github.com/coredns/coredns
-SRC ?= github.com/coredns/coredns
+PKG_COREDNS ?= github.com/coredns/coredns
+SRC_COREDNS ?= github.com/coredns/coredns
+PKG_AUTOSCALER ?= github.com/kubernetes-sigs/cluster-proportional-autoscaler
+SRC_AUTOSCALER ?= github.com/kubernetes-sigs/cluster-proportional-autoscaler 
 TAG ?= v1.8.3$(BUILD_META)
+export DOCKER_BUILDKIT?=1
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)
@@ -18,29 +21,61 @@ ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
-.PHONY: image-build
-image-build:
+AUTOSCALER_BUILD_TAG := $(TAG:v%=%)
+
+.PHONY: image-build-coredns
+image-build-coredns:
 	docker build \
 		--pull \
-		--build-arg PKG=$(PKG) \
-		--build-arg SRC=$(SRC) \
+		--build-arg PKG=$(PKG_COREDNS) \
+		--build-arg SRC=$(SRC_COREDNS) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
+		--target coredns \
 		--tag $(ORG)/hardened-coredns:$(TAG) \
 		--tag $(ORG)/hardened-coredns:$(TAG)-$(ARCH) \
 	.
 
-.PHONY: image-push
-image-push:
+.PHONY: image-push-coredns
+image-push-coredns:
 	docker push $(ORG)/hardened-coredns:$(TAG)-$(ARCH)
 
-.PHONY: image-manifest
-image-manifest:
+.PHONY: image-manifest-coredns
+image-manifest-coredns:
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
 		$(ORG)/hardened-coredns:$(TAG) \
 		$(ORG)/hardened-coredns:$(TAG)-$(ARCH)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
 		$(ORG)/hardened-coredns:$(TAG)
 
-.PHONY: image-scan
-image-scan:
+.PHONY: image-scan-coredns
+image-scan-coredns:
 	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-coredns:$(TAG)
+
+.PHONY: image-build-autoscaler
+image-build-autoscaler:
+	docker build \
+		--pull \
+		--build-arg PKG=$(PKG_AUTOSCALER) \
+		--build-arg SRC=$(SRC_AUTOSCALER) \
+		--build-arg TAG=$(AUTOSCALER_BUILD_TAG:$(BUILD_META)=) \
+		--target autoscaler \
+		--tag $(ORG)/hardened-cluster-autoscaler:$(TAG) \
+		--tag $(ORG)/hardened-cluster-autoscaler:$(TAG)-$(ARCH) \
+	.
+
+.PHONY: image-push-autoscaler
+image-push-autoscaler:
+	docker push $(ORG)/hardened-cluster-autoscaler:$(TAG)-$(ARCH)
+
+.PHONY: image-manifest-autoscaler
+image-manifest-autoscaler:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
+		$(ORG)/hardened-cluster-autoscaler:$(TAG) \
+		$(ORG)/hardened-cluster-autoscaler:$(TAG)-$(ARCH)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
+		$(ORG)/hardened-cluster-autoscaler:$(TAG)
+
+.PHONY: image-scan-autoscaler
+image-scan-autoscaler:
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-cluster-autoscaler:$(TAG)
+


### PR DESCRIPTION
Add the cluster autoscaler hardening to the image-build

The austoscaler will be deployed with coredns by default starting with 1.22

Linked issue: https://github.com/rancher/rke2/issues/1473

Signed-off-by: Manuel Buil <mbuil@suse.com>