### PR TITLE
Harden dns nodeCache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,7 @@ steps:
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-build-coredns
   - make DRONE_TAG=${DRONE_TAG} image-build-autoscaler
+  - make DRONE_TAG=${DRONE_TAG} image-build-dnsnodecache
   volumes:
   - name: docker
     path: /var/run/docker.sock
@@ -24,6 +25,7 @@ steps:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push-coredns image-manifest-coredns
   - make DRONE_TAG=${DRONE_TAG} image-push-autoscaler image-manifest-autoscaler
+  - make DRONE_TAG=${DRONE_TAG} image-push-dnsnodecache image-manifest-dnsnodecache
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -41,6 +43,7 @@ steps:
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-scan-coredns
   - make DRONE_TAG=${DRONE_TAG} image-scan-autoscaler
+  - make DRONE_TAG=${DRONE_TAG} image-scan-dnsnodecache
   volumes:
   - name: docker
     path: /var/run/docker.sock

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # rancher/hardened-coredns
 
-## Build
+## Build coredns
 
 ```sh
-TAG=v1.8.3 make
+TAG=v1.8.3 make image-build-coredns
+```
+
+## Build autoscaler
+
+```sh
+TAG=v1.8.3 make image-build-autoscaler
+```
+
+## Build dns nodechar
+
+```sh
+NODECACHE_TAG=1.19.1 make image-build-dnsnodecache
 ```


### PR DESCRIPTION
Harden dns nodeCache and add netcat to the image so that we can remove busybox from the chart

Linked issue: https://github.com/rancher/rke2/issues/1473

Signed-off-by: Manuel Buil <mbuil@suse.com>