### PR TITLE
Bump hardened-build-base and split out CPA version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ platform:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.8b7
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-build-coredns
   - make DRONE_TAG=${DRONE_TAG} image-build-autoscaler
@@ -19,7 +19,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.8b7
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push-coredns
@@ -37,7 +37,7 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.8b7
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-scan-coredns
   - make DRONE_TAG=${DRONE_TAG} image-scan-autoscaler
@@ -65,7 +65,7 @@ node:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.8b7
   failure: ignore
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-build-coredns
@@ -75,7 +75,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.8b7
   failure: ignore
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.16.10b7
-ARG TAG="v1.8.5"
+ARG GO_IMAGE=rancher/hardened-build-base:v1.17.8b7
+ARG TAG="v1.9.1"
 ARG ARCH="amd64"
 FROM ${UBI_IMAGE} as ubi
 FROM ${GO_IMAGE} as base-builder
@@ -37,8 +37,8 @@ FROM base-builder as autoscaler-builder
 ARG SRC=github.com/kubernetes-sigs/cluster-proportional-autoscaler
 ARG PKG=github.com/kubernetes-sigs/cluster-proportional-autoscaler
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
-ARG TAG
-ARG ARCH
+ARG TAG="1.8.5"
+ARG ARCH="amd64"
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PKG_COREDNS ?= github.com/coredns/coredns
 SRC_COREDNS ?= github.com/coredns/coredns
 PKG_AUTOSCALER ?= github.com/kubernetes-sigs/cluster-proportional-autoscaler
 SRC_AUTOSCALER ?= github.com/kubernetes-sigs/cluster-proportional-autoscaler 
-TAG ?= v1.8.5$(BUILD_META)
+TAG ?= v1.9.1$(BUILD_META)
 export DOCKER_BUILDKIT?=1
 
 ifneq ($(DRONE_TAG),)
@@ -21,7 +21,8 @@ ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
-AUTOSCALER_BUILD_TAG := $(TAG:v%=%)
+AUTOSCALER_BUILD_TAG := 1.8.5
+AUTOSCALER_TAG := v$(AUTOSCALER_BUILD_TAG)$(BUILD_META)
 
 .PHONY: image-build-coredns
 image-build-coredns:
@@ -58,26 +59,26 @@ image-build-autoscaler:
 		--pull \
 		--build-arg PKG=$(PKG_AUTOSCALER) \
 		--build-arg SRC=$(SRC_AUTOSCALER) \
-		--build-arg TAG=$(AUTOSCALER_BUILD_TAG:$(BUILD_META)=) \
+		--build-arg TAG=$(AUTOSCALER_BUILD_TAG) \
 		--build-arg ARCH=$(ARCH) \
 		--target autoscaler \
-		--tag $(ORG)/hardened-cluster-autoscaler:$(TAG) \
-		--tag $(ORG)/hardened-cluster-autoscaler:$(TAG)-$(ARCH) \
+		--tag $(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG) \
+		--tag $(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG)-$(ARCH) \
 	.
 
 .PHONY: image-push-autoscaler
 image-push-autoscaler:
-	docker push $(ORG)/hardened-cluster-autoscaler:$(TAG)-$(ARCH)
+	docker push $(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG)-$(ARCH)
 
 .PHONY: image-manifest-autoscaler
 image-manifest-autoscaler:
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-cluster-autoscaler:$(TAG) \
-		$(ORG)/hardened-cluster-autoscaler:$(TAG)-$(ARCH)
+		$(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG) \
+		$(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG)-$(ARCH)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-cluster-autoscaler:$(TAG)
+		$(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG)
 
 .PHONY: image-scan-autoscaler
 image-scan-autoscaler:
-	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-cluster-autoscaler:$(TAG)
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG)
 


### PR DESCRIPTION
The cluster proportional autoscaler does not release alongside coredns; the versions should not be pinned together.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>