### PR TITLE
BCI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.17.8b7
 ARG TAG="v1.9.1"
 ARG ARCH="amd64"
-FROM ${UBI_IMAGE} as ubi
+FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as base-builder
 # setup required packages
 RUN set -x \
@@ -50,14 +50,10 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
     fi
 RUN install -s cluster-proportional-autoscaler /usr/local/bin
 
-FROM ubi as coredns
-RUN microdnf update -y && \
-    rm -rf /var/cache/yum
+FROM bci as coredns
 COPY --from=coredns-builder /usr/local/bin/coredns /coredns
 ENTRYPOINT ["/coredns"]
 
-FROM ubi as autoscaler
-RUN microdnf update -y && \
-    rm -rf /var/cache/yum
+FROM bci as autoscaler
 COPY --from=autoscaler-builder /usr/local/bin/cluster-proportional-autoscaler /cluster-proportional-autoscaler
 ENTRYPOINT ["/cluster-proportional-autoscaler"]


### PR DESCRIPTION
This PR replaces UBI7 with BCI in the final base image. Related to https://github.com/rancher/rke2/issues/3260.