### PR TITLE
Update coredns and autoscaler versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
-ARG TAG="v1.10.1"
+ARG TAG="v1.11.1"
 ARG ARCH="amd64"
 FROM ${GO_IMAGE} as base-builder
 # setup required packages
@@ -35,11 +35,11 @@ FROM base-builder as autoscaler-builder
 ARG SRC=github.com/kubernetes-sigs/cluster-proportional-autoscaler
 ARG PKG=github.com/kubernetes-sigs/cluster-proportional-autoscaler
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
-ARG TAG="1.8.6"
+ARG TAG="1.8.10"
 ARG ARCH="amd64"
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
-RUN git checkout tags/${TAG} -b ${TAG}
+RUN git checkout tags/v${TAG} -b ${TAG}
 RUN GOARCH=${ARCH} GO_LDFLAGS="-linkmode=external -X ${PKG}/pkg/version.VERSION=${TAG}" \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o . ./...
 RUN go-assert-static.sh cluster-proportional-autoscaler

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PKG_COREDNS ?= github.com/coredns/coredns
 SRC_COREDNS ?= github.com/coredns/coredns
 PKG_AUTOSCALER ?= github.com/kubernetes-sigs/cluster-proportional-autoscaler
 SRC_AUTOSCALER ?= github.com/kubernetes-sigs/cluster-proportional-autoscaler 
-TAG ?= v1.10.1$(BUILD_META)
+TAG ?= v1.11.1$(BUILD_META)
 export DOCKER_BUILDKIT?=1
 
 ifneq ($(DRONE_TAG),)
@@ -27,7 +27,7 @@ ifeq (,$(filter %$(BUILD_META),$(TAG)))
 	$(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
-AUTOSCALER_BUILD_TAG := 1.8.6
+AUTOSCALER_BUILD_TAG := 1.8.10
 AUTOSCALER_TAG := v$(AUTOSCALER_BUILD_TAG)$(BUILD_META)
 
 .PHONY: image-build-coredns

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Build
 
 ```sh
-TAG=v1.8.3 make
+TAG=v1.11.1 make
 ```


### PR DESCRIPTION
The new versions fix the serious CVEs:
* CVE-2022-41723
* CVE-2023-39325
* GHSA-m425-mq94-257g

found by trivy