### PR TITLE
Fix drone bug. Autoscaler image not being pushed

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -155,6 +155,15 @@ platform:
   os: linux
   arch: amd64
 steps:
+  - name: extract-tag
+    image: alpine
+    commands:
+      - apk add --no-cache make
+      - echo $(make -s print-autoscaler-tag) > ./tag.txt
+    when:
+      event:
+        - tag
+
   - name: push
     image: plugins/manifest:1.2.3
     settings:
@@ -164,9 +173,11 @@ steps:
         from_secret: docker_username
       spec: manifest-autoscaler.tmpl
       ignore_missing: true
+      template: ./tag.txt
     when:
       event:
         - tag
+
 depends_on:
   - linux-amd64
   - linux-arm64

--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,6 @@ image-manifest-autoscaler:
 image-scan-autoscaler:
 	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-cluster-autoscaler:$(AUTOSCALER_TAG)
 
+.PHONY: print-autoscaler-tag
+print-autoscaler-tag:
+	echo ${AUTOSCALER_TAG}

--- a/manifest-autoscaler.tmpl
+++ b/manifest-autoscaler.tmpl
@@ -1,12 +1,13 @@
-image: rancher/hardened-cluster-autoscaler:{{build.tag}}
+# {{ . }} is consuming the extracted value in tag.txt templated in manifest-autoscaler drone pipeline
+image: rancher/hardened-cluster-autoscaler:{{ . }}
 manifests:
   -
-    image: rancher/hardened-cluster-autoscaler:{{build.tag}}-amd64
+    image: rancher/hardened-cluster-autoscaler:{{ . }}-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/hardened-cluster-autoscaler:{{build.tag}}-arm64
+    image: rancher/hardened-cluster-autoscaler:{{ . }}-arm64
     platform:
       architecture: arm64
       os: linux


### PR DESCRIPTION
Since a manifest.tmpl file was contributed and drone changed for multi-arch, autoscaler image has not been pushed because it does not use the same tag as coredns.

This PR fixes that