### PR TITLE
Use updatecli to update coredns version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
-ARG TAG="v1.11.1"
 ARG ARCH="amd64"
 FROM ${GO_IMAGE} as base-builder
 # setup required packages
@@ -15,7 +14,7 @@ FROM base-builder as coredns-builder
 ARG SRC=github.com/coredns/coredns
 ARG PKG=github.com/coredns/coredns
 ARG ARCH
-ARG TAG
+ARG TAG=v1.11.1
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune

--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -1,0 +1,74 @@
+---
+name: "Update coredns version" 
+
+sources:
+ coredns:
+   name: Get coredns version
+   kind: githubrelease
+   spec:
+     owner: coredns
+     repository: coredns
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: latest
+
+targets:
+  dockerfile:
+    name: "Bump to latest coredns version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: coredns
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "TAG"
+
+  makefile:
+    name: "Bump to latest coredns version in Makefile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^TAG \?\= (.*)'
+      replacepattern: 'TAG ?= {{ source "coredns" }}$$(BUILD_META)'
+
+  readme:
+    name: "Bump to latest coredns version in README"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: README.md
+      matchpattern: '(?m)^TAG=(.*)'
+      replacepattern: 'TAG={{ source "coredns" }} make'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump coredns version to {{ source "coredns" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default
+

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,3 +3,6 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "image-build-coredns"
+  branch: "master"
+  owner: "rancher"


### PR DESCRIPTION
This PR will make updatecli update the coredns version whenever upstream releases a new one

Seems to work: https://github.com/rancher/image-build-coredns/pull/37