### PR TITLE
Move to bci-busybox instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.14b1
 ARG ARCH="amd64"
+FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as base-builder
 # setup required packages
 RUN set -x && \
@@ -29,6 +31,6 @@ RUN if [ "${ARCH}" != "s390x" || "${ARCH}" != "arm64" ]; then \
 RUN install -s bin/* /usr/local/bin
 RUN coredns --version
 
-FROM scratch as coredns
+FROM bci as coredns
 COPY --from=coredns-builder /usr/local/bin/coredns /coredns
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
As described https://github.com/rancher/image-build-coredns/issues/47, we need common CA certificates to be able to contact upstream DNS servers over TLS. Bci-busybox includes these certificates and is small enough to reduce CVEs. Just to confirm that bci-busybox includes the certificates:
```
docker run -ti registry.suse.com/bci/bci-busybox ls /etc/ssl/certs | wc -l
423
```