### PR TITLE
updatecli: add `latest: true` typefilter

### DIFF
--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -13,6 +13,7 @@ sources:
        release: true
        draft: false
        prerelease: false
+       latest: true
      versionfilter:
        kind: latest
 


### PR DESCRIPTION
Ensure UpdateCli chooses the tagged `latest` release, instead of choosing the most recent chronological release

Fixes: https://github.com/rancher/rke2/issues/6371