### PR TITLE
publish-image action

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -18,14 +18,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Set the TAG value
-      id: get-TAG
-      run: |
-        echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
     - name: "Read secrets"
       uses: rancher-eio/read-vault-secrets@main
       with:
@@ -33,22 +25,12 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to Container Registry
-      uses: docker/login-action@v3
+    - name: Build and push image
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
-
-    - name: Build container image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        push: true
-        tags: rancher/hardened-coredns:${{ github.event.release.tag_name }}
-        file: Dockerfile
-        platforms: linux/amd64, linux/arm64
-        build-args: |
-          TAG=${{ env.TAG }}
+        image: hardened-coredns
+        tag: ${{ github.event.release.tag_name }}
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        push-to-prime: false

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -23,14 +23,22 @@ jobs:
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
 
     - name: Build and push image
       uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
         image: hardened-coredns
         tag: ${{ github.event.release.tag_name }}
+
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-        push-to-prime: false
+
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
-ARG ARCH="amd64"
 
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
@@ -19,7 +18,6 @@ RUN set -x && \
 FROM --platform=$BUILDPLATFORM base-builder as coredns-builder
 ARG SRC=github.com/coredns/coredns
 ARG PKG=github.com/coredns/coredns
-ARG ARCH
 ARG TAG=v1.11.3
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
@@ -27,13 +25,13 @@ RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
 RUN go mod download
 # cross-compilation setup
-ARG TARGETPLATFORM
+ARG TARGETPLATFORM TARGETARCH
 RUN xx-go --wrap && \
     GO_LDFLAGS="-linkmode=external -X ${PKG}/coremain.GitCommit=$(git rev-parse --short HEAD)" \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/coredns .
 RUN go-assert-static.sh bin/*
 RUN xx-verify --static bin/*
-RUN if [ "${ARCH}" != "s390x" || "${ARCH}" != "arm64" ]; then \
+RUN if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; then \
     	go-assert-boring.sh bin/*; \
     fi
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ BUILD_OPTS = \
 	--build-arg PKG=$(PKG) \
 	--build-arg SRC=$(SRC) \
 	--build-arg TAG=$(TAG:$(BUILD_META)=) \
-	--target coredns \
 	--tag "$(IMAGE)"
 
 .PHONY: image-build

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ image-build:
 push-image:
 	docker buildx build \
 		$(BUILD_OPTS) \
+		$(IID_FILE_FLAG) \
 		--sbom=true \
 		--attest type=provenance,mode=max \
 		--push \


### PR DESCRIPTION
- use rancher/ecm-distro-tools/actions/publish-image to build and push images
- adds make target push-image
- adds sbom to docker build arguments
- signs images that are pushed to the prime registry