### PR TITLE
Fix broken `image-scan` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ log:
 
 .PHONY: image-scan
 image-scan:
-	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-coredns:$(TAG)
+	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(IMAGE)


### PR DESCRIPTION
The Makefile no longer defines an `ORG` var
Fixup for c8ee6123892222f5de9397ecd878722cf32cd6ab

Also resolve Dockerfile warnings: https://github.com/rancher/image-build-coredns/pull/92