### PR TITLE
updatecli: restrict semver to the `1.x.x` release

### DIFF
--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -15,6 +15,8 @@ sources:
        prerelease: false
      versionfilter:
        kind: semver
+       # Avoid obsolete/incorrect releases (e.g. `v011`, etc.)
+       pattern: '~1'
 
 targets:
   dockerfile:


### PR DESCRIPTION
Avoid obsolete/incorrect releases (e.g. `v011`, etc.)