### PR TITLE
Revert "Patch grpc/otel for CVE reasons"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
-RUN go mod edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3 && \
-    go mod edit -replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0 && \
-    go mod tidy
 RUN go mod download
 # cross-compilation setup
 ARG TARGETPLATFORM TARGETARCH


### PR DESCRIPTION
Upstream coredns 1.14.3 is released.
This reverts commit 4676f992de8e6c5923de6c1938276b0c9f4fa7f0.