### PR TITLE
Switch base image to bci-nano to reduce CVE footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
+ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.25.11b1
 
 # Image that provides cross compilation tooling.


### PR DESCRIPTION
## What

Switch the runtime base image from `registry.suse.com/bci/bci-busybox` to `registry.suse.com/bci/bci-nano:16.0`.

## Why

The image built from `bci-busybox` regularly carries glibc CVEs inherited from the SLE BCI base. `bci-nano` is a much smaller base, shrinking the runtime surface and reducing the CVE footprint.

CoreDNS is a fully static binary run directly via `ENTRYPOINT ["/coredns"]`, so it needs no shell or iptables. Unlike the prior art in rancher/image-build-dns-nodecache#169 — which had to pull a static busybox + iptables from k3s-root because `bci-nano` ships no shell — this image requires only the one-line base swap.

## Testing

- Full cross-compiled `make image-build` succeeds on the new base.
- `docker run --rm <image> --version` runs correctly from the resulting nano-based image:
  ```
  CoreDNS-1.14.4
  linux/arm64, go1.25.11 X:boringcrypto, 232d7cac3
  ```

Prior art: rancher/image-build-dns-nodecache#169